### PR TITLE
Add Hellraiser Ironclad Rare Power card

### DIFF
--- a/cards/ironclad/__init__.py
+++ b/cards/ironclad/__init__.py
@@ -22,6 +22,7 @@ from cards.ironclad.limit_break import LimitBreak
 from cards.ironclad.pummel import Pummel
 from cards.ironclad.uppercut import Uppercut
 from cards.ironclad.offering import Offering
+from cards.ironclad.hellraiser import Hellraiser
 
 __all__ = [
     # Starter
@@ -31,5 +32,5 @@ __all__ = [
     # Uncommon
     'Clothesline', 'Inflame', 'BodySlam', 'Carnage',
     # Rare
-    'Bludgeon', 'LimitBreak', 'Pummel', 'Uppercut', 'Offering',
+    'Bludgeon', 'LimitBreak', 'Pummel', 'Uppercut', 'Offering', 'Hellraiser',
 ]

--- a/cards/ironclad/hellraiser.py
+++ b/cards/ironclad/hellraiser.py
@@ -1,0 +1,38 @@
+"""
+Ironclad Rare Power card - Hellraiser
+"""
+from engine.runtime_api import add_action, add_actions
+
+from typing import List
+from actions.base import Action
+from actions.combat import ApplyPowerAction
+from cards.base import Card
+from entities.creature import Creature
+from utils.registry import register
+from utils.types import CardType, RarityType
+
+
+@register("card")
+class Hellraiser(Card):
+    """Whenever you draw a card containing "Strike" it is played against a random enemy."""
+
+    card_type = CardType.POWER
+    rarity = RarityType.RARE
+
+    base_cost = 1
+
+    def on_play(self, targets: List[Creature] = []):
+        target = targets[0] if targets else None
+        from engine.game_state import game_state
+
+        super().on_play(targets)
+
+        actions = []
+        # Apply HellraiserPower
+        actions.append(ApplyPowerAction(power="HellraiserPower", target=game_state.player, amount=1, duration=-1))
+
+        from engine.game_state import game_state
+
+        add_actions(actions)
+
+        return

--- a/powers/definitions/__init__.py
+++ b/powers/definitions/__init__.py
@@ -14,6 +14,7 @@ from powers.definitions.invincible import InvinciblePower
 from powers.definitions.frail import FrailPower
 from powers.definitions.magnetism import MagnetismPower
 from powers.definitions.mayhem import MayhemPower
+from powers.definitions.hellraiser import HellraiserPower
 from powers.definitions.panache import PanachePower
 from powers.definitions.sadistic_nature import SadisticNaturePower
 from powers.definitions.the_bomb import TheBombPower
@@ -79,6 +80,7 @@ __all__ = [
     "FrailPower",
     "MagnetismPower",
     "MayhemPower",
+    "HellraiserPower",
     "PanachePower",
     "SadisticNaturePower",
     "TheBombPower",

--- a/powers/definitions/hellraiser.py
+++ b/powers/definitions/hellraiser.py
@@ -1,0 +1,49 @@
+"""
+Hellraiser power for Ironclad.
+Whenever you draw a card containing "Strike", it is played against a random enemy.
+"""
+from engine.runtime_api import add_action, add_actions
+from typing import Any
+from powers.base import Power, StackType
+from actions.combat import PlayCardAction
+from utils.registry import register
+
+
+@register("power")
+class HellraiserPower(Power):
+    """Whenever you draw a card containing "Strike", it is played against a random enemy."""
+
+    name = "Hellraiser"
+    description = "Whenever you draw a card containing \"Strike\" it is played against a random enemy."
+    stack_type = StackType.PRESENCE
+    is_buff = True
+
+    def __init__(self, amount: int = 1, duration: int = -1, owner=None):
+        """
+        Args:
+            amount: Not used
+            duration: -1 for permanent
+        """
+        super().__init__(amount=amount, duration=duration, owner=owner)
+
+    def on_card_draw(self, card: Any):
+        """Play the drawn card automatically if it contains "Strike" in its name."""
+        # Check if the card name contains "Strike" case-insensitive
+        card_name = ""
+        
+        # Try to get the name from display_name
+        if hasattr(card, 'display_name'):
+            try:
+                card_name = card.display_name.resolve()
+            except:
+                pass
+        
+        # Fallback to class name
+        if not card_name and hasattr(card, '__class__'):
+            card_name = card.__class__.__name__
+        
+        if card_name and "strike" in card_name.lower():
+            # Play the card automatically against a random enemy without expending energy
+            add_actions([PlayCardAction(card=card, is_auto=True, ignore_energy=True)])
+        
+        return


### PR DESCRIPTION
Adds a new Ironclad Rare Power card called Hellraiser.

Card Details:
- Name: Hellraiser (Hellraiser+ when upgraded)
- Energy Cost: 1
- Rarity: Rare
- Type: Power
- Description: Whenever you draw a card containing Strike it is played against a random enemy.

Power Details:
- New HellraiserPower triggers on_card_draw
- Checks if drawn card name contains Strike case-insensitive (Strike, Pommel Strike, etc.)
- Automatically plays matching cards against random enemy without expending energy using PlayCardAction with is_auto=True and ignore_energy=True

Implementation:
- Created cards/ironclad/hellraiser.py - New Rare Power card
- Created powers/definitions/hellraiser.py - New power with on_card_draw hook
- Updated cards/ironclad/__init__.py - Added Hellraiser import/export
- Updated powers/definitions/__init__.py - Added HellraiserPower import/export

Follows existing patterns from MayhemPower and EvolvePower. Existing tests should not be broken.